### PR TITLE
send-errors-for-dev-and-prod

### DIFF
--- a/packages/server/src/app/utils/error/error.ts
+++ b/packages/server/src/app/utils/error/error.ts
@@ -10,7 +10,6 @@ class AppError extends Error {
     this.message = message;
     this.statusCode = statusCode;
     this.status = `${statusCode}`.startsWith('4') ? 'fail' : 'error';
-    // this.status = 'fail';
     this.isOperational = true;
 
     Error.captureStackTrace(this, this.constructor);

--- a/packages/server/src/app/utils/error/globalErrorHandler.ts
+++ b/packages/server/src/app/utils/error/globalErrorHandler.ts
@@ -1,16 +1,62 @@
-import { ErrorRequestHandler } from 'express';
+import { ErrorRequestHandler, Response } from 'express';
+import AppError from './error';
+
+const handleErrorsForDevTestEnv = (err: ErrorProps, res: Response) => {
+  if (err.isOperational) {
+    return res.status(err.statusCode).json({
+      status: err.status,
+      message: err.message,
+    });
+  } else {
+    return res.status(err.statusCode).json({
+      status: err.status,
+      message: err.message,
+      stack: err.stack,
+      error: err.error,
+    });
+  }
+};
+
+const handleErrorsForProdEnv = (err: ErrorProps, res: Response) => {
+  if (err.isOperational) {
+    return res.status(err.statusCode).json({
+      status: err.status,
+      message: err.message,
+    });
+  } else {
+    // all unhandled errors in production
+    console.error('ERROR', err);
+    return res.status(500).json({
+      status: 'error',
+      message: 'Something went wrong!!!',
+    });
+  }
+};
 
 const globalErrorHandler: ErrorRequestHandler = (err, req, res, next) => {
-  const statusCode = err.statusCode || 500;
-  const status = err.status || 'error';
-  const message = err.message || 'Internal Server Error';
-
-  res.status(statusCode).json({
-    status,
-    message,
+  const errorProps: ErrorProps = {
+    statusCode: err.statusCode || 500,
+    status: err.status || 'error',
+    message: err.message,
     stack: err.stack,
     error: err,
-  });
+    isOperational: err.isOperational,
+  };
+
+  if (['development', 'test'].includes(process.env.NODE_ENV as string)) {
+    handleErrorsForDevTestEnv(errorProps, res);
+  } else {
+    handleErrorsForProdEnv(errorProps, res);
+  }
 };
 
 export default globalErrorHandler;
+
+type ErrorProps = {
+  status: 'fail';
+  statusCode: number;
+  message: string;
+  stack: string;
+  error: AppError | Error;
+  isOperational?: boolean;
+};


### PR DESCRIPTION
Write functions that handle errors i.e send different errors to client for dev, test and prod environments.